### PR TITLE
Update Result C++ Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 
 ### C++ Projects
 
-- [**Result**](https://github.com/threeal/result) [WIP],
+- [**Result**](https://github.com/threeal/result) [[v0.1.0]](https://github.com/threeal/result/releases/tag/v0.1.0),
   a simple C++ implementation of [Rust Result](https://doc.rust-lang.org/std/result/), an alternative to [Abseil Status](https://abseil.io/docs/cpp/guides/status).
 - [**Math**](https://github.com/threeal/math) [WIP],
   a simple C++ [math](https://en.wikipedia.org/wiki/Mathematics) library.


### PR DESCRIPTION
Update the latest version info of [Result C++](https://github.com/threeal/result) project to [v0.1.0](https://github.com/threeal/result/releases/tag/v0.1.0).