### PR TITLE
Update @actions-kit/dev Latest Version Info to v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
   - [@actions-kit/cache](https://github.com/threeal/actions-kit/tree/main/packages/cache) [WIP],
     a file caching library.
   - [@actions-kit/dev](https://github.com/threeal/actions-kit/tree/main/packages/dev)
-    [[v0.1.1]](https://github.com/threeal/actions-kit/releases/tag/dev%40v0.1.1),
-    a development configuration library.
+    [[v0.2.0]](https://github.com/threeal/actions-kit/releases/tag/dev%40v0.2.0),
+    a development tool library.
   - [@actions-kit/envi](https://github.com/threeal/actions-kit/tree/main/packages/envi)
     [[v0.1.0]](https://github.com/threeal/actions-kit/releases/tag/envi%40v0.1.0),
     an environment management library.


### PR DESCRIPTION
Update the latest version info of [@actions-kit/dev](https://github.com/threeal/actions-kit/tree/main/packages/dev) to [v0.2.0](https://github.com/threeal/actions-kit/releases/tag/dev%40v0.2.0).