### PR TITLE
Update GitHub Pages Deployment

### DIFF
--- a/.github/workflows/animations.yaml
+++ b/.github/workflows/animations.yaml
@@ -1,4 +1,4 @@
-name: daily
+name: Snake Animations
 on:
   workflow_dispatch:
   pull_request:
@@ -8,9 +8,10 @@ on:
     - cron: "0 16 * * *"
 jobs:
   generate:
+    name: Generate Animations
     runs-on: ubuntu-latest
     steps:
-      - name: Generate grid snake animations
+      - name: Generate snake animations
         uses: Platane/snk@v3.0.0
         with:
           github_user_name: ${{ github.repository_owner }}
@@ -21,12 +22,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload artifact
+      - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v2.0.0
         with:
           path: dist
 
   deploy:
+    name: Deploy to Pages
     if: github.event_name != 'pull_request'
     needs: generate
     runs-on: ubuntu-latest
@@ -41,9 +43,9 @@ jobs:
       group: pages
       cancel-in-progress: false
     steps:
-      - name: Setup Pages
+      - name: Configure Pages
         uses: actions/configure-pages@v3.0.6
 
-      - name: Deploy Pages
+      - name: Deploy to Pages
         id: deployment
         uses: actions/deploy-pages@v2.0.4

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -26,16 +26,6 @@ jobs:
         with:
           path: dist
 
-      - name: Push animations to output branch
-        if: github.event_name != 'pull_request'
-        uses: crazy-max/ghaction-github-pages@v3.2.0
-        with:
-          target_branch: output
-          build_dir: dist
-          keep_history: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   deploy:
     if: github.event_name != 'pull_request'
     needs: generate

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -21,11 +21,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload animations as an artifact
-        uses: actions/upload-artifact@v3.1.3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2.0.0
         with:
-          name: animation
-          path: dist/
+          path: dist
 
       - name: Push animations to output branch
         if: github.event_name != 'pull_request'

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -35,3 +35,25 @@ jobs:
           keep_history: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: generate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v3.0.6
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v2.0.4

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
   a code parser for a [Doxygen](https://www.doxygen.nl/) project.
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/threeal/threeal/output/grid-snake-dark.svg" />
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/threeal/threeal/output/grid-snake-light.svg" />
-  <img alt="GitHub contribution animation" src="https://raw.githubusercontent.com/threeal/threeal/output/grid-snake.svg" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://threeal.github.io/threeal/grid-snake-dark.svg" />
+  <source media="(prefers-color-scheme: light)" srcset="https://threeal.github.io/threeal/grid-snake-light.svg" />
+  <img alt="GitHub contribution animation" src="https://threeal.github.io/threeal/grid-snake.svg" />
 </picture>


### PR DESCRIPTION
This pull request renames the `daily.yml` workflow to `animation.yaml` and modifies it to deploy the snake animations to GitHub Pages instead of pushing them to the `output` branch. This resolves #24.