### PR TITLE
Update Dependabot Label Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: [chore]


### PR DESCRIPTION
This pull request updates the configuration for the Dependabot label, changing it to use the `chore` label.