### PR TITLE
Remove `GITHUB_TOKEN` Environment from Generate Snake Animations Workflow

### DIFF
--- a/.github/workflows/animations.yaml
+++ b/.github/workflows/animations.yaml
@@ -19,8 +19,6 @@ jobs:
             dist/grid-snake.svg
             dist/grid-snake-dark.svg?palette=github-dark
             dist/grid-snake-light.svg?palette=github-light
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v2.0.0


### PR DESCRIPTION
This pull request removed the `GITHUB_TOKEN` environment in the `Generate snake animations` workflow since it is not required anymore since [Platane/snk@v3.2.0](https://github.com/Platane/snk/releases/tag/v3.2.0).