### PR TITLE
Limit GitHub Pages Deployment to the Main Branch

### DIFF
--- a/.github/workflows/animations.yaml
+++ b/.github/workflows/animations.yaml
@@ -27,7 +27,7 @@ jobs:
 
   deploy:
     name: Deploy to Pages
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.ref_name == 'main'
     needs: generate
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This pull request makes a straightforward adjustment by restricting the "Deploy to Pages" job within the CI workflow to execute only when the branch name is `main`. It closes #38.