### PR TITLE
Switch to Platane/snk/svg-only for Improved Performance

### DIFF
--- a/.github/workflows/animations.yaml
+++ b/.github/workflows/animations.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate snake animations
-        uses: Platane/snk@v3.2.0
+        uses: Platane/snk/svg-only@v3.2.0
         with:
           github_user_name: ${{ github.repository_owner }}
           outputs: |


### PR DESCRIPTION
This pull request updates the action for generating snake animations to utilize [Platane/snk/svg-only](https://github.com/Platane/snk/tree/main/svg-only), enhancing performance. It closes #39.