### PR TITLE
Replace Entry for Devel.cmake with CheckWarning.cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
   a cross-platform C++ audio volume control library.
 - [**Minimal C++ Starter**](https://github.com/threeal/minimal-cpp-starter),
   a minimal C++ template to kickstart your project.
-- [**Devel.cmake**](https://github.com/threeal/Devel.cmake) [WIP],
-  streamline your CMake project with package management, code formatting, and static analysis tools.
+- [**CheckWarning.cmake**](https://github.com/threeal/CheckWarning.cmake)
+  [[v1.0.0]](https://github.com/threeal/CheckWarning.cmake/releases/tag/v1.0.0),
+  check for compiler warnings in your CMake project.
 
 ### Go Projects
 


### PR DESCRIPTION
This pull request replaces entry for Devel.cmake with [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake) because of changes in that project name as explained in https://github.com/threeal/CheckWarning.cmake/issues/11.