### PR TITLE
Remove WIP Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 
 - [**Result**](https://github.com/threeal/result) [[v0.1.0]](https://github.com/threeal/result/releases/tag/v0.1.0),
   a simple C++ implementation of [Rust Result](https://doc.rust-lang.org/std/result/), an alternative to [Abseil Status](https://abseil.io/docs/cpp/guides/status).
-- [**Minimal C++ Starter**](https://github.com/threeal/minimal-cpp-starter),
-  a minimal C++ template to kickstart your project.
 - [**CheckWarning.cmake**](https://github.com/threeal/CheckWarning.cmake)
   [[v1.0.0]](https://github.com/threeal/CheckWarning.cmake/releases/tag/v1.0.0),
   check for compiler warnings in your CMake project.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 
 - [**Result**](https://github.com/threeal/result) [[v0.1.0]](https://github.com/threeal/result/releases/tag/v0.1.0),
   a simple C++ implementation of [Rust Result](https://doc.rust-lang.org/std/result/), an alternative to [Abseil Status](https://abseil.io/docs/cpp/guides/status).
-- [**Cpp**](https://github.com/threeal/cpp),
-  a comprehensive collection of C++ utility packages.
-  It contains the following packages:
-  - [Error](https://github.com/threeal/cpp/tree/main/error) [WIP],
-    a C++ package that provides utilities for error handling.
 - [**Math**](https://github.com/threeal/math) [WIP],
   a simple C++ [math](https://en.wikipedia.org/wiki/Mathematics) library.
 - [**Volume C++**](https://github.com/threeal/volume-cpp) [WIP],

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Also, a fast learner and generalist who can develop multiple things like
 ## My Works
 
 Aside from my current job, I also work on several personal projects.
-Currently, most of these projects are in [C++](https://isocpp.org/) and [Go](https://go.dev/),
+Currently, most of these projects are in [C++](https://isocpp.org/),
   while others are [GitHub Actions](https://github.com/features/actions) for utilizing my other projects.
 Please refer to [my repositories](https://github.com/threeal?tab=repositories) for a list of all projects that I have done.
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 - [**CMake Action**](https://github.com/threeal/cmake-action)
   [[v1.2.0]](https://github.com/threeal/cmake-action/releases/tag/v1.2.0),
   configure, build, and test your [CMake](https://cmake.org/) project using GitHub Actions.
-- [**CTest Action**](https://github.com/threeal/ctest-action) [WIP],
-  test your CMake project with [CTest](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html) using GitHub Actions.
 - [**Gcovr Action**](https://github.com/threeal/gcovr-action/) [[v0.2.0]](https://github.com/threeal/gcovr-action/releases/tag/v0.2.0),
   generate code coverage reports for a C++ project on GitHub Actions using [gcovr](https://gcovr.com/en/stable/).
 - [**Actions Kit**](https://github.com/threeal/actions-kit),

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 
 - [**Result**](https://github.com/threeal/result) [[v0.1.0]](https://github.com/threeal/result/releases/tag/v0.1.0),
   a simple C++ implementation of [Rust Result](https://doc.rust-lang.org/std/result/), an alternative to [Abseil Status](https://abseil.io/docs/cpp/guides/status).
-- [**Volume C++**](https://github.com/threeal/volume-cpp) [WIP],
-  a cross-platform C++ audio volume control library.
 - [**Minimal C++ Starter**](https://github.com/threeal/minimal-cpp-starter),
   a minimal C++ template to kickstart your project.
 - [**CheckWarning.cmake**](https://github.com/threeal/CheckWarning.cmake)

--- a/README.md
+++ b/README.md
@@ -48,15 +48,6 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
   [[v1.0.0]](https://github.com/threeal/CheckWarning.cmake/releases/tag/v1.0.0),
   check for compiler warnings in your CMake project.
 
-### Go Projects
-
-- [**Bro**](https://github.com/threeal/bro) [WIP],
-  your friendly, personal, multi-purpose [buddy](https://en.wiktionary.org/wiki/buddy) written in Go.
-- [**Shell Go**](https://github.com/threeal/shell-go) [WIP],
-  a Go package for executing shell commands.
-- [**Starter Go**](https://github.com/threeal/starter-go),
-  a minimalistic Go template to kickstart your project.
-
 ### GitHub Actions Projects
 
 - [**Composite Action Starter**](https://github.com/threeal/composite-action-starter)

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 - [**Google Rank**](https://github.com/threeal/google-rank)
   [[v0.2.0]](https://github.com/threeal/google-rank/releases/tag/v0.2.0),
   retrieve the [Google](https://www.google.com/) search ranking of your website for specific keywords.
-- [**Doxycode**](https://github.com/threeal/doxycode) [WIP],
-  a code parser for a [Doxygen](https://www.doxygen.nl/) project.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://threeal.github.io/threeal/grid-snake-dark.svg" />

--- a/README.md
+++ b/README.md
@@ -64,25 +64,6 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
   configure, build, and test your [CMake](https://cmake.org/) project using GitHub Actions.
 - [**Gcovr Action**](https://github.com/threeal/gcovr-action/) [[v0.2.0]](https://github.com/threeal/gcovr-action/releases/tag/v0.2.0),
   generate code coverage reports for a C++ project on GitHub Actions using [gcovr](https://gcovr.com/en/stable/).
-- [**Actions Kit**](https://github.com/threeal/actions-kit),
-  an additional [toolkit](https://github.com/actions/toolkit) for developing GitHub Actions.
-  It contains the following packages:
-  - [@actions-kit/cache](https://github.com/threeal/actions-kit/tree/main/packages/cache) [WIP],
-    a file caching library.
-  - [@actions-kit/dev](https://github.com/threeal/actions-kit/tree/main/packages/dev)
-    [[v0.2.0]](https://github.com/threeal/actions-kit/releases/tag/dev%40v0.2.0),
-    a development tool library.
-  - [@actions-kit/envi](https://github.com/threeal/actions-kit/tree/main/packages/envi)
-    [[v0.1.0]](https://github.com/threeal/actions-kit/releases/tag/envi%40v0.1.0),
-    an environment management library.
-  - [@actions-kit/exec](https://github.com/threeal/actions-kit/tree/main/packages/exec)
-    [[v0.2.0]](https://github.com/threeal/actions-kit/releases/tag/exec%40v0.2.0),
-    a command execution library.
-  - [@actions-kit/log](https://github.com/threeal/actions-kit/tree/main/packages/log) [WIP],
-    a console log library.
-  - [@actions-kit/pip](https://github.com/threeal/actions-kit/tree/main/packages/pip) [WIP],
-    a [pip](https://pypi.org/project/pip) package management library.
-
 
 ### Other Projects
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 
 - [**Result**](https://github.com/threeal/result) [[v0.1.0]](https://github.com/threeal/result/releases/tag/v0.1.0),
   a simple C++ implementation of [Rust Result](https://doc.rust-lang.org/std/result/), an alternative to [Abseil Status](https://abseil.io/docs/cpp/guides/status).
-- [**Math**](https://github.com/threeal/math) [WIP],
-  a simple C++ [math](https://en.wikipedia.org/wiki/Mathematics) library.
 - [**Volume C++**](https://github.com/threeal/volume-cpp) [WIP],
   a cross-platform C++ audio volume control library.
 - [**Minimal C++ Starter**](https://github.com/threeal/minimal-cpp-starter),


### PR DESCRIPTION
This pull request removes the following projects from the list:
- C++ projects: [Cpp](https://github.com/threeal/cpp), [Math](https://github.com/threeal/math), [Volume C++](https://github.com/threeal/volume-cpp), and [Minimal C++ Starter](https://github.com/threeal/minimal-cpp-starter).
- All Go projects: [Bro](https://github.com/threeal/bro), [Shell Go](https://github.com/threeal/shell-go), and [Starter Go](https://github.com/threeal/starter-go).
- GitHub Actions projects: [CTest Action](https://github.com/threeal/ctest-action) and [Actions Kit](https://github.com/threeal/actions-kit).
- Other project: [Doxycode](https://github.com/threeal/doxycode).

It closes #45.