### PR TITLE
Add Git Attributes Configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png binary


### PR DESCRIPTION
This pull request simply adds a `.gitattributes` file that set the attribute of `*.png` files to be binary.