### PR TITLE
Fix Permission in Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,7 @@ jobs:
     needs: generate-animations
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pages: write
       id-token: write


### PR DESCRIPTION
This pull request set the `actions` permission to `read` to fix the following deploy job issue in the main branch:

https://github.com/threeal/threeal/actions/runs/7274830063/job/19821546680

It also removes the `content` permission since it appears unnecessary during deployment.