### PR TITLE
Audit Permission in Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,6 @@ jobs:
     needs: generate-animations
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       pages: write
       id-token: write
     environment:


### PR DESCRIPTION
This pull request reverts a change made in #65 by removing the `actions` permission from the `deploy` job in the `deploy.yaml` workflow. The `actions` permission no longer required for Pages deployment since the version 4.0.1 of actions/deploy-pages action (see #66).