### PR TITLE
Change Yarn Install Action Entry to Setup Yarn Berry Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
   A minimalistic GitHub repository template to kickstart your [GitHub Action](https://github.com/features/actions) project.
 - [**Composite Action Starter**](https://github.com/threeal/composite-action-starter):
   A minimalistic GitHub repository template to kickstart your [GitHub composite action](https://github.com/features/actions) project.
-- [**Yarn Install Action**](https://github.com/threeal/yarn-install-action):
-  Install Node.js dependencies using [Yarn](https://yarnpkg.com/) with cache support on GitHub Actions.
+- [**Setup Yarn Berry Action**](https://github.com/threeal/yarn-install-action):
+  Set up [Yarn](https://yarnpkg.com/) to a specified version and install Node.js project with cache support on GitHub Actions.
 - [**Setup Poetry Action**](https://github.com/threeal/setup-poetry-action):
   Set up your GitHub Actions workflow with a specific version of [Poetry](https://python-poetry.org).
 - [**ROS 2 Workspace Action**](https://github.com/ichiro-its/ros2-ws-action):


### PR DESCRIPTION
This pull request resolves #77 by simply changing the entry of the Yarn Install Action to Setup Yarn Berry Action.