### PR TITLE
Remove Configure Pages Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,9 +38,6 @@ jobs:
       group: pages
       cancel-in-progress: false
     steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v5.0.0
-
       - name: Deploy Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
This pull request resolves #90 by removing the Configure Pages action from the Deploy Pages job.