### PR TITLE
Add SetupGo.cmake Project Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
   Fix source codes formatting in your CMake project.
 - [**GitCheckout.cmake**](https://github.com/threeal/git-checkout-cmake):
   Clone and check out a [Git](https://git-scm.com/) repository from a CMake project.
+- [**SetupGo.cmake**](https://github.com/threeal/setup-go-cmake):
+  Set up a specific version of [Go](https://go.dev/) from a CMake project.
 
 ### Node.js Projects
 


### PR DESCRIPTION
This pull request simply adds an entry for the [SetupGo.cmake](https://github.com/threeal/setup-go-cmake) project in the CMake Projects section.