### PR TITLE
Add Cache Action Project Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 
 - [**Action Starter**](https://github.com/threeal/action-starter):
   A minimalistic GitHub repository template to kickstart your [GitHub Action](https://github.com/features/actions) project.
+- [**Cache Action**](https://github.com/threeal/cache-action): Save and restore files as a cache in GitHub Actions.
 - [**Setup Yarn Berry Action**](https://github.com/threeal/yarn-install-action):
   Set up [Yarn](https://yarnpkg.com/) to a specified version and install Node.js project with cache support on GitHub Actions.
 - [**Pipx Install Action**](https://github.com/threeal/pipx-install-action):


### PR DESCRIPTION
This pull request simply adds an entry for the [Cache Action](https://github.com/threeal/cache-action) project in the GitHub Actions Projects section.