### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-format:
     name: Check Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   generate-animations:
     name: Generate Animations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate Snake Animations
         uses: Platane/snk/svg-only@v3.2.0
@@ -27,7 +27,7 @@ jobs:
   deploy-pages:
     name: Deploy Pages
     needs: generate-animations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
This pull request resolves #107 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.