### PR TITLE
Configure Dependabot Label to Empty

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,4 +6,4 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]
+    labels: []


### PR DESCRIPTION
This pull request resolves #115 by configuring Dependabot labels in the `dependabot.yaml` file to an empty array, ensuring that Dependabot won't assign any labels to newly created pull requests.