### PR TITLE
Add Setup Standalone pnpm Action Project Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Please refer to [my repositories](https://github.com/threeal?tab=repositories) f
 - [**Action Starter**](https://github.com/threeal/action-starter):
   A minimalist template for starting a new [GitHub Action](https://github.com/features/actions) project.
 - [**Cache Action**](https://github.com/threeal/cache-action): Save and restore files as a cache in GitHub Actions.
+- [**Setup Standalone pnpm Action**](https://github.com/threeal/setup-pnpm-action):
+  Set up standalone [pnpm](https://pnpm.io/) with a specified version in GitHub Actions
 - [**Setup Yarn Berry Action**](https://github.com/threeal/yarn-install-action):
   Set up [Yarn](https://yarnpkg.com/) to a specified version and install Node.js project with cache support on GitHub Actions.
 - [**Pipx Install Action**](https://github.com/threeal/pipx-install-action):


### PR DESCRIPTION
This pull request adds an entry for the [Setup Standalone pnpm Action](https://github.com/threeal/setup-pnpm-action) project in the GitHub Actions Projects section.