### PR TITLE
Remove Unused Git Attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.png binary


### PR DESCRIPTION
This pull request resolves #122 by removing the unused `.gitattributes` file.