### PR TITLE
Use `npx` to Run Prettier on CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,10 +12,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
       - name: Check Formatting
-        run: |
-          yarn dlx prettier --write .
-          git diff --exit-code HEAD
+        run: npx --yes prettier --check .


### PR DESCRIPTION
This pull request resolves #124 by modifying the Check workflow to utilize `npx` for running Prettier, simplifying the steps for formatting the source code.