### PR TITLE
Integrate Lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,8 @@
+pre-commit:
+  piped: true
+  jobs:
+    - name: fix formatting
+      run: npx --yes prettier --check .
+
+    - name: check diff
+      run: git diff --exit-code {staged_files}


### PR DESCRIPTION
This pull request resolves #128 by integrating [Lefthook](https://lefthook.dev/) into this template, allowing pre-commit hooks to be installed and executed on staged files.