### PR TITLE
Merge Jobs in Deploy CI Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,29 +4,10 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: "0 16 * * *"
+    - cron: 0 16 * * *
 jobs:
-  generate-animations:
-    name: Generate Animations
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Generate Snake Animations
-        uses: Platane/snk/svg-only@v3.3.0
-        with:
-          github_user_name: ${{ github.repository_owner }}
-          outputs: |
-            dist/grid-snake.svg
-            dist/grid-snake-dark.svg?palette=github-dark
-            dist/grid-snake-light.svg?palette=github-light
-
-      - name: Upload Snake Animations
-        uses: actions/upload-pages-artifact@v3.0.1
-        with:
-          path: dist
-
   deploy-pages:
     name: Deploy Pages
-    needs: generate-animations
     runs-on: ubuntu-24.04
     permissions:
       pages: write
@@ -38,6 +19,20 @@ jobs:
       group: pages
       cancel-in-progress: false
     steps:
+      - name: Generate Snake Animations
+        uses: Platane/snk/svg-only@v3.3.0
+        with:
+          github_user_name: ${{ github.repository_owner }}
+          outputs: |
+            dist/grid-snake.svg
+            dist/grid-snake-dark.svg?palette=github-dark
+            dist/grid-snake-light.svg?palette=github-light
+
+      - name: Upload Pages
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: dist
+
       - name: Deploy Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
This pull request resolves #132 by merging jobs in the `deploy.yaml` CI workflow into one `deploy-pages` job.