### PR TITLE
Update CI to validate pre-commit hooks

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,5 +12,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Check Formatting
-        uses: dprint/check@v2.3
+      - name: Install dprint
+        run: |
+          curl -fsSL https://dprint.dev/install.sh | sh
+          echo "$HOME/.dprint/bin" >> $GITHUB_PATH
+
+      - name: Install Lefthook
+        run: |
+          curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash
+          sudo apt install lefthook
+
+      - name: Check pre-commit hook
+        run: lefthook run pre-commit --all-files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,5 +19,5 @@ The Lefthook pre-commit hook runs `dprint fmt` automatically before every commit
 
 ## CI
 
-- **check.yaml** — runs `dprint check` on pull requests and pushes to `main`
+- **check.yaml** — runs the Lefthook pre-commit hook across all files on pull requests and pushes to `main`; fails if `dprint fmt` produces any changes
 - **deploy.yaml** — generates the snake contribution animation (via Platane/snk) and deploys to GitHub Pages; triggers daily, on push to `main`, or manually


### PR DESCRIPTION
Resolves #156

Update the CI workflow to run pre-commit hooks across all files instead of executing formatting checks directly, ensuring the hooks themselves are validated in CI.