### PR TITLE
Update CI naming conventions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,12 @@
-name: Check
+name: CI
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  check-format:
-    name: Check Formatting
+  check:
+    name: Check
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,12 +14,12 @@ jobs:
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deploy-pages.outputs.page_url }}
     concurrency:
       group: pages
       cancel-in-progress: false
     steps:
-      - name: Generate Snake Animations
+      - name: Generate snake animations
         uses: Platane/snk/svg-only@v3.5.0
         with:
           github_user_name: ${{ github.repository_owner }}
@@ -28,11 +28,11 @@ jobs:
             dist/grid-snake-dark.svg?palette=github-dark
             dist/grid-snake-light.svg?palette=github-light
 
-      - name: Upload Pages
+      - name: Upload pages
         uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: dist
 
-      - name: Deploy Pages
-        id: deployment
+      - name: Deploy pages
+        id: deploy-pages
         uses: actions/deploy-pages@v5.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,5 +19,5 @@ The Lefthook pre-commit hook runs `dprint fmt` automatically before every commit
 
 ## CI
 
-- **check.yaml** — runs the Lefthook pre-commit hook across all files on pull requests and pushes to `main`; fails if `dprint fmt` produces any changes
+- **ci.yaml** — runs the Lefthook pre-commit hook across all files on pull requests and pushes to `main`; fails if `dprint fmt` produces any changes
 - **deploy.yaml** — generates the snake contribution animation (via Platane/snk) and deploys to GitHub Pages; triggers daily, on push to `main`, or manually


### PR DESCRIPTION
## Summary

- Rename `check.yaml` to `ci.yaml` and update workflow name to `CI`
- Rename job `check-format` to `check` with name `Check`
- Update step names in `deploy.yaml` to sentence case
- Update `CLAUDE.md` to reference renamed workflow file

Closes #158